### PR TITLE
feat: add star-based difficulty selector

### DIFF
--- a/index.html
+++ b/index.html
@@ -38,6 +38,18 @@
                     <span class="slider"></span>
                 </label>
             </div>
+
+            <div class="control-group">
+                <label>难度选择:</label>
+                <div class="difficulty-selection">
+                    <input type="radio" id="difficulty-1" name="difficulty" value="1" checked>
+                    <label for="difficulty-1">⭐</label>
+                    <input type="radio" id="difficulty-2" name="difficulty" value="2">
+                    <label for="difficulty-2">⭐⭐</label>
+                    <input type="radio" id="difficulty-3" name="difficulty" value="3">
+                    <label for="difficulty-3">⭐⭐⭐</label>
+                </div>
+            </div>
         </div>
 
         <div class="game-info">

--- a/style.css
+++ b/style.css
@@ -79,6 +79,27 @@ header p {
     transition: border-color 0.3s;
 }
 
+.difficulty-selection {
+    display: flex;
+    gap: 8px;
+    align-items: center;
+}
+
+.difficulty-selection input {
+    display: none;
+}
+
+.difficulty-selection label {
+    font-size: 20px;
+    cursor: pointer;
+    color: #adb5bd;
+    transition: color 0.3s;
+}
+
+.difficulty-selection input:checked + label {
+    color: #ffd700;
+}
+
 .api-input-group {
     display: flex;
     gap: 8px;


### PR DESCRIPTION
## Summary
- add difficulty selector UI with one-, two-, and three-star options
- style the star buttons with highlight when selected

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b65ceb7368833186d5b5f30c5d63d9